### PR TITLE
more specific property handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.egg
 *.pyc
 .coverage
+.cache
 cover/
 dist/
 nosetests.xml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+- added spec config include_read_only_properties
+- added spec config expand_missing_properties
+- added spec config pass_property_on_missing_spec
+
 4.2.2 (2016-04-01)
 ------------------
 - Fix marshalling of an optional array query parameter when not passed in the

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -3,6 +3,15 @@ from collections import Mapping
 from bravado_core.exception import SwaggerMappingError
 
 
+class SwaggerReadOnly(Exception):
+    """Raised if a property is read only and include_read_only_properties is
+    set to False in the swagger spec configuration
+
+    This is an internal exception and is catched in the unmarshal_object
+    implementation.
+    """
+
+
 # 'object' and 'array' are omitted since this should really be read as
 # "Swagger types that map to python primitives"
 SWAGGER_PRIMITIVES = (
@@ -24,6 +33,16 @@ def get_default(swagger_spec, schema_object_spec):
 
 def is_required(swagger_spec, schema_object_spec):
     return swagger_spec.deref(schema_object_spec).get('required', False)
+
+
+def is_read_only(swagger_spec, schema_object_spec):
+    return swagger_spec.deref(schema_object_spec).get('readOnly', False)
+
+
+def raise_if_read_only(swagger_spec, schema_object_spec):
+    if not swagger_spec.config.get('include_read_only_properties', True) \
+       and is_read_only(swagger_spec, schema_object_spec):
+        raise SwaggerReadOnly()
 
 
 def has_format(swagger_spec, schema_object_spec):

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -50,7 +50,19 @@ CONFIG_DEFAULTS = {
     # :class:`bravado_core.formatter.SwaggerFormat`. These formats are in
     # addition to the formats already supported by the Swagger 2.0
     # Specification.
-    'formats': []
+    'formats': [],
+
+    # Include readOnly properties in unmarshalled data
+    'include_read_only_properties': True,
+
+    # Unmarshaller will insert a property with value `None` if it is not
+    # provided in the input data
+    'expand_missing_properties': True,
+
+    # Unmarshaller blindly passes properties with a missing spec entry
+    # If set to False only properties defined in the spec are in the result of
+    # the unmarshaller
+    'pass_property_on_missing_spec': True,
 }
 
 

--- a/tests/schema/is_read_only_test.py
+++ b/tests/schema/is_read_only_test.py
@@ -1,0 +1,44 @@
+import pytest
+
+from bravado_core.schema import is_read_only
+from bravado_core.spec import Spec
+
+
+@pytest.fixture
+def is_read_only_true():
+    return {'type': 'integer', 'readOnly': True}
+
+
+@pytest.fixture
+def is_read_only_false():
+    return {'type': 'integer', 'readOnly': False}
+
+
+def test_true(minimal_swagger_spec, is_read_only_true):
+    assert is_read_only(minimal_swagger_spec, is_read_only_true)
+
+
+def test_false(minimal_swagger_spec, is_read_only_false):
+    assert not is_read_only(minimal_swagger_spec, is_read_only_false)
+
+
+def test_defaults_to_false(minimal_swagger_spec):
+    assert not is_read_only(minimal_swagger_spec, {'type': 'integer'})
+
+
+def test_ref_true(minimal_swagger_dict, is_read_only_true):
+    minimal_swagger_dict['definitions']['Foo'] = is_read_only_true
+    swagger_spec = Spec(minimal_swagger_dict)
+    assert is_read_only(swagger_spec, {'$ref': '#/definitions/Foo'})
+
+
+def test_ref_false(minimal_swagger_dict, is_read_only_false):
+    minimal_swagger_dict['definitions']['Foo'] = is_read_only_false
+    swagger_spec = Spec(minimal_swagger_dict)
+    assert not is_read_only(swagger_spec, {'$ref': '#/definitions/Foo'})
+
+
+def test_ref_default_to_false(minimal_swagger_dict):
+    minimal_swagger_dict['definitions']['Foo'] = {'type': 'integer'}
+    swagger_spec = Spec.from_dict(minimal_swagger_dict)
+    assert not is_read_only(swagger_spec, {'$ref': '#/definitions/Foo'})

--- a/tests/schema/raise_if_read_only_test.py
+++ b/tests/schema/raise_if_read_only_test.py
@@ -1,0 +1,87 @@
+import pytest
+
+from bravado_core.schema import raise_if_read_only, SwaggerReadOnly
+from bravado_core.spec import Spec
+
+
+@pytest.fixture
+def raise_if_read_only_true():
+    return {'type': 'integer', 'readOnly': True}
+
+
+@pytest.fixture
+def raise_if_read_only_false():
+    return {'type': 'integer', 'readOnly': False}
+
+
+@pytest.fixture
+def include_read_only_properties_true():
+    return {'include_read_only_properties': True}
+
+
+@pytest.fixture
+def include_read_only_properties_false():
+    return {'include_read_only_properties': False}
+
+
+def test_read_only_true_do_not_include(minimal_swagger_dict,
+                                       raise_if_read_only_true,
+                                       include_read_only_properties_false):
+    swagger_spec = Spec(minimal_swagger_dict,
+                        config=include_read_only_properties_false)
+    with pytest.raises(SwaggerReadOnly):
+        raise_if_read_only(swagger_spec, raise_if_read_only_true)
+
+
+def test_read_only_true_include(minimal_swagger_dict,
+                                raise_if_read_only_true,
+                                include_read_only_properties_true):
+    swagger_spec = Spec(minimal_swagger_dict,
+                        config=include_read_only_properties_true)
+    raise_if_read_only(swagger_spec, raise_if_read_only_true)
+
+
+def test_read_only_false_do_not_include(minimal_swagger_dict,
+                                        raise_if_read_only_false,
+                                        include_read_only_properties_false):
+    swagger_spec = Spec(minimal_swagger_dict,
+                        config=include_read_only_properties_false)
+    raise_if_read_only(swagger_spec, raise_if_read_only_false)
+
+
+def test_read_only_false_include(minimal_swagger_dict,
+                                 raise_if_read_only_false,
+                                 include_read_only_properties_true):
+    swagger_spec = Spec(minimal_swagger_dict,
+                        config=include_read_only_properties_true)
+    raise_if_read_only(swagger_spec, raise_if_read_only_false)
+
+
+def test_defaults_to_false(minimal_swagger_spec):
+    raise_if_read_only(minimal_swagger_spec,
+                       {'type': 'integer', 'readOnly': True})
+
+
+def test_ref_true(minimal_swagger_dict,
+                  raise_if_read_only_true,
+                  include_read_only_properties_true):
+    minimal_swagger_dict['definitions']['Foo'] = raise_if_read_only_true
+    swagger_spec = Spec(minimal_swagger_dict,
+                        config=include_read_only_properties_true)
+    raise_if_read_only(swagger_spec, {'$ref': '#/definitions/Foo'})
+
+
+def test_ref_false(minimal_swagger_dict,
+                   raise_if_read_only_true,
+                   include_read_only_properties_false):
+    minimal_swagger_dict['definitions']['Foo'] = raise_if_read_only_true
+    swagger_spec = Spec(minimal_swagger_dict,
+                        config=include_read_only_properties_false)
+    with pytest.raises(SwaggerReadOnly):
+        raise_if_read_only(swagger_spec, {'$ref': '#/definitions/Foo'})
+
+
+def test_ref_default_to_false(minimal_swagger_dict):
+    minimal_swagger_dict['definitions']['Foo'] = {'type': 'integer'}
+    swagger_spec = Spec.from_dict(minimal_swagger_dict)
+    raise_if_read_only(swagger_spec, {'$ref': '#/definitions/Foo'})

--- a/tests/unmarshal/unmarshal_missing_properties_test.py
+++ b/tests/unmarshal/unmarshal_missing_properties_test.py
@@ -1,0 +1,50 @@
+from bravado_core.spec import Spec
+from bravado_core.unmarshal import unmarshal_schema_object
+
+
+def test_missing_properties_true(minimal_swagger_dict):
+    swagger_spec = Spec.from_dict(
+                        minimal_swagger_dict,
+                        config={'expand_missing_properties': True})
+    object_spec = {
+        'type': 'object',
+        'properties': {
+            'name': {
+                'type': 'string',
+            },
+            'title': {
+                'type': 'string',
+            },
+        }
+    }
+
+    result = unmarshal_schema_object(
+        swagger_spec,
+        object_spec,
+        {'title': 'title'})
+    assert result['name'] is None
+    assert 'title' in result
+
+
+def test_missing_properties_false(minimal_swagger_dict):
+    swagger_spec = Spec.from_dict(
+                        minimal_swagger_dict,
+                        config={'expand_missing_properties': False})
+    object_spec = {
+        'type': 'object',
+        'properties': {
+            'name': {
+                'type': 'string',
+            },
+            'title': {
+                'type': 'string',
+            },
+        }
+    }
+
+    result = unmarshal_schema_object(
+        swagger_spec,
+        object_spec,
+        {'title': 'title'})
+    assert 'name' not in result
+    assert 'title' in result

--- a/tests/unmarshal/unmarshal_missing_spec_test.py
+++ b/tests/unmarshal/unmarshal_missing_spec_test.py
@@ -1,0 +1,44 @@
+from bravado_core.spec import Spec
+from bravado_core.unmarshal import unmarshal_schema_object
+
+
+def test_missing_spec_true(minimal_swagger_dict):
+    swagger_spec = Spec.from_dict(
+                        minimal_swagger_dict,
+                        config={'pass_property_on_missing_spec': True})
+    object_spec = {
+        'type': 'object',
+        'properties': {
+            'name': {
+                'type': 'string',
+            },
+        }
+    }
+
+    result = unmarshal_schema_object(
+        swagger_spec,
+        object_spec,
+        {'name': 'name', 'title': 'title'})
+    assert 'title' in result
+    assert 'name' in result
+
+
+def test_missing_spec_false(minimal_swagger_dict):
+    swagger_spec = Spec.from_dict(
+                        minimal_swagger_dict,
+                        config={'pass_property_on_missing_spec': False})
+    object_spec = {
+        'type': 'object',
+        'properties': {
+            'name': {
+                'type': 'string',
+            },
+        }
+    }
+
+    result = unmarshal_schema_object(
+        swagger_spec,
+        object_spec,
+        {'name': 'name', 'title': 'title'})
+    assert 'title' not in result
+    assert 'name' in result

--- a/tests/unmarshal/unmarshal_read_only_test.py
+++ b/tests/unmarshal/unmarshal_read_only_test.py
@@ -1,0 +1,66 @@
+import pytest
+
+from bravado_core.spec import Spec
+from bravado_core.unmarshal import unmarshal_schema_object
+
+
+@pytest.fixture
+def include_read_only_properties_false():
+    return {
+        'include_read_only_properties': False,
+        'expand_missing_properties': False
+    }
+
+
+@pytest.fixture
+def include_read_only_properties_true():
+    return {
+        'include_read_only_properties': True,
+        'expand_missing_properties': False
+    }
+
+
+@pytest.fixture
+def unmarshall_simple_read_only_object_dict():
+    return {
+        'type': 'object',
+        'properties': {
+            'name': {
+                'type': 'string',
+                'readOnly': True
+            },
+            'title': {
+                'type': 'string',
+            },
+        }
+    }
+
+
+def test_unmarshall_read_only_true(minimal_swagger_dict,
+                                   include_read_only_properties_false,
+                                   unmarshall_simple_read_only_object_dict):
+    swagger_spec = Spec.from_dict(
+                        minimal_swagger_dict,
+                        config=include_read_only_properties_false)
+
+    result = unmarshal_schema_object(
+        swagger_spec,
+        unmarshall_simple_read_only_object_dict,
+        {'name': 'name', 'title': 'title'})
+    assert 'name' not in result
+    assert 'title' in result
+
+
+def test_unmarshall_read_only_false(minimal_swagger_dict,
+                                    include_read_only_properties_true,
+                                    unmarshall_simple_read_only_object_dict):
+    swagger_spec = Spec.from_dict(
+                        minimal_swagger_dict,
+                        config=include_read_only_properties_true)
+
+    result = unmarshal_schema_object(
+        swagger_spec,
+        unmarshall_simple_read_only_object_dict,
+        {'name': 'name', 'title': 'title'})
+    assert result['name'] == 'name'
+    assert 'title' in result


### PR DESCRIPTION
The unmarshaller is now able to not forward readOnly properties and can
be configured to not expand missing properties.
This can be configured via the spec config object.
